### PR TITLE
Context fixes, restore url updating

### DIFF
--- a/wiki.html
+++ b/wiki.html
@@ -127,7 +127,6 @@ var Lineup = React.createClass({
     var newLineup = this.state.lineup.slice(0);
     newLineup.push(this.createInstance(detail.context, detail.site, detail.slug, detail.title))
     this.setState({ lineup: newLineup })
-    // window.location.hash = "#" + this.urlFromInstances(newLineup)
   },
   pageAvailable: function(event) {
     var detail = event.detail
@@ -152,6 +151,13 @@ var Lineup = React.createClass({
     window.addEventListener("appendToLineup", this.appendToLineup, false)
     window.addEventListener("pageAvailable", this.pageAvailable, false)
     window.addEventListener("popstate", this.onPopstate, false)
+  },
+  componentDidUpdate: function() {
+    loading = this.state.lineup.find(function(item) { return item.site == undefined })
+
+    if (!loading) {
+      window.location.hash = "#" + this.urlFromInstances(this.state.lineup)
+    }
   },
   render: function() {
     function toSegment(instance) {

--- a/wiki.html
+++ b/wiki.html
@@ -244,8 +244,8 @@ var Remote = React.createClass({
 
         var source = 'http://' + this.props.site + '/' + this.props.slug + '.json'
         this.serverRequest = $.get(source, function (result) {
-          context = [this.props.site]
-          journal = result.journal || []
+          var context = [this.props.site]
+          var journal = result.journal || []
           journal.reverse().forEach(ammend(context))
 
           var detail = { id: this.props.id, context: context,
@@ -346,7 +346,7 @@ var Reference = React.createClass({
 var Video = React.createClass({
   render: function() {
     var parse = function(text) {
-      result = { caption: "" }
+      var result = { caption: "" }
       var lines = text.split(/\r\n?|\n/)
       for (i = 0; i < lines.length; i++) {
         var line = lines[i]
@@ -385,7 +385,7 @@ var Video = React.createClass({
     return (
       <div className="item">
         {player}
-        <i><ResolvedText context={context} text={result.caption} /></i>
+        <i><ResolvedText context={this.props.context} text={result.caption} /></i>
       </div>
     )
   }
@@ -444,7 +444,7 @@ var ResolvedText = React.createClass({
           return text.split(/(\[https?:.*? .*?\]|\[\[.*?\]\])/)
         }
 
-        function span(site, slug) {
+        function span(context, site, slug) {
           return function (split, index) {
             if (split.startsWith("[[")) {
               return <InternalLink key={index} context={context} text={split.slice(2, -2)} site={site} />
@@ -459,7 +459,7 @@ var ResolvedText = React.createClass({
         }
 
         var spans = splitText(this.props.text)
-        return <span>{spans.map(span(this.props.site, this.props.slug))}</span>
+        return <span>{spans.map(span(this.props.context, this.props.site, this.props.slug))}</span>
     }
 })
 

--- a/wiki.html
+++ b/wiki.html
@@ -125,7 +125,7 @@ var Lineup = React.createClass({
   appendToLineup: function(event) {
     var detail = event.detail
     var newLineup = this.state.lineup.slice(0);
-    newLineup.push(this.createInstance(detail.context, detail.site, detail.slug))
+    newLineup.push(this.createInstance(detail.context, detail.site, detail.slug, detail.title))
     this.setState({ lineup: newLineup })
     // window.location.hash = "#" + this.urlFromInstances(newLineup)
   },


### PR DESCRIPTION
Turns out our _new_ code wasn't the bug--the old code had a bug instead! We were using `context` in places without qualifying with `var`, so it was coming from `window` unexpectedly 😡 

With those fixed, noticed that we weren't using the title passed on link clicks. Fixed that.

Lastly, plugged the URL updates back in, but this time wired them to the React lifecycle event `componentDidUpdate`. With the two ways to update the lineup state now, that seemed more correct than calling a function alongside when we `setState`.

Things I noticed:
- Forward/back is showing flashes of content rather than holding them around. I wonder if we're losing IDs and reloading somewhere along the way.
- Still have duplication between `Resolution` and `Remote`.
- Could use some tidying in `Lineup` around where we use the three main component types. With them all using `Page` maybe we could use another top-level component instead of using a `div` there?
- All the baggage we pass between the various levels has me feeling like there's some abstraction that wants to get out there, but it's not 100% clear to me just yet.
