### PR TITLE
readme points to read.wiki.org

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -5,7 +5,7 @@ We will share only json schema with current fedwiki.
 We will write conventional react code and give up if we can't make that work.
 We will build this into a single js file that includes all available plugins also rewritten in react.
 
-See our [work in progress](http://jasonrclark.com/small-client-wiki/wiki.html) served from github pages.
+See our [work in progress](http://read.wiki.org) served from github pages.
 
 # build
 


### PR DESCRIPTION
As we get closer to production usage we should choose a good public place. As a subdomain of wiki.org I chose read (for read-only) rather than small or client which characterized the code, not the usage. I have fed.wiki too and read.fed.wiki seems like a great name to use when we have this relatively finished.

See http://read.wiki.org
