### PR TITLE
Prefer text to caption for images

### DIFF
--- a/index.html
+++ b/index.html
@@ -308,7 +308,7 @@ var Image = React.createClass({
     return (
     <div className="item surround">
       <img src={this.props.item.url} />
-      <div className="caption">{this.props.item.caption}</div>
+      <div className="caption">{this.props.item.text || this.props.item.caption}</div>
     </div>
     )
   }


### PR DESCRIPTION
Some old images have captions. Now we prefer to use the text field which is easily edited as the caption. For some historic reason drag-and-drop writes its template caption in the deprecated caption field so we still look there too.
