### PR TITLE
Refactor Markdown plugin to use ResolvedText

### DIFF
--- a/index.html
+++ b/index.html
@@ -319,7 +319,7 @@ var Markdown = React.createClass({
   render: function() {
     return (
       <div className="item" className={this.props.item.type}>
-        <MarkdownText {...this.props} text={this.props.item.text} />
+        <ResolvedText {...this.props} textComponent={MarkedText} text={this.props.item.text} />
       </div>
     )
   }
@@ -445,6 +445,20 @@ var PlainText = React.createClass({
   }
 })
 
+var MarkedText = React.createClass({
+  rawMarkup: function() {
+    var md = new Remarkable('full')
+    var rawMarkup = md.render(this.props.text.toString())
+    rawMarkup = rawMarkup.replace(/\<h[12]/gi, '<h3')
+    rawMarkup = rawMarkup.replace(/\<li\>\[x\]/gi, '<li>&#9745; ')
+    rawMarkup = rawMarkup.replace(/\<li\>\[ \]/gi, '<li>&#9744; ')
+    return { __html: rawMarkup }
+  },
+  render: function(){
+    return <span dangerouslySetInnerHTML={this.rawMarkup()} />
+  }
+})
+
 var ExternalLink = React.createClass({
   render: function() {
     var m = this.props.text.match(/\[(https?:.*?) (.*?)\]/)
@@ -476,6 +490,7 @@ var ResolvedText = React.createClass({
         }
 
         function span(props) {
+          var TextComponent = props.textComponent || PlainText
           return function (split, index) {
             if (split.startsWith("[[")) {
               return <InternalLink key={index} {...props} text={split.slice(2, -2)} />
@@ -484,47 +499,7 @@ var ResolvedText = React.createClass({
               return <ExternalLink key={index} {...props} text={split} />
             }
             else {
-              return <PlainText key={index} {...props} text={split} />
-            }
-          }
-        }
-
-        var spans = splitText(this.props.text)
-        return <span>{spans.map(span(this.props))}</span>
-    }
-})
-
-var MarkedText = React.createClass({
-  rawMarkup: function() {
-    var md = new Remarkable('full')
-    var rawMarkup = md.render(this.props.text.toString())
-    rawMarkup = rawMarkup.replace(/\<h[12]/gi, '<h3')
-    rawMarkup = rawMarkup.replace(/\<li\>\[x\]/gi, '<li>&#9745; ')
-    rawMarkup = rawMarkup.replace(/\<li\>\[ \]/gi, '<li>&#9744; ')
-    return { __html: rawMarkup }
-  },
-  
-  render: function(){
-        return <span dangerouslySetInnerHTML={this.rawMarkup()} />
-    }
-})
-
-var MarkdownText = React.createClass({
-    render: function(){
-        function splitText(text) {
-          return text.split(/(\[https?:.*? .*?\]|\[\[.*?\]\])/)
-        }
-
-        function span(props) {
-          return function (split, index) {
-            if (split.startsWith("[[")) {
-              return <InternalLink key={index} {...props} text={split.slice(2, -2)} />
-            }
-            else if (split.startsWith("[")) {
-              return <ExternalLink key={index} {...props} text={split} />
-            }
-            else {
-              return <MarkedText key={index} {...props} text={split} />
+              return <TextComponent key={index} {...props} text={split} />
             }
           }
         }


### PR DESCRIPTION
Noticed in reviewing that the `MarkdownText` component was duplicating `ResolvedText` but with `MarkedText` replacing the `PlainText` components.

To avoid the duplication, this instead allows `ResolvedText` to receive a `textComponent` class through `props`, defaulting to `PlainText` if none is given.

What do you think @paul90, @WardCunningham?
