### PR TITLE
A better version of Markdown item rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -146,7 +146,7 @@ var Lineup = React.createClass({
   },
   appendToLineup: function(event) {
     var detail = event.detail
-    console.log("Detail: " + details)
+    console.log("Detail: " + detail)
     var newLineup = this.state.lineup.slice(0);
     newLineup.push(this.createInstance(detail.context, detail.site, detail.slug, detail.title))
     this.setState({ lineup: newLineup })

--- a/index.html
+++ b/index.html
@@ -95,7 +95,7 @@ iframe {
 <script src="https://fb.me/react-dom-0.14.6.js"></script>
 <script src="http://fb.me/JSXTransformer-0.12.1.js"></script>
 <script src="https://code.jquery.com/jquery-3.1.0.js"></script>
-<script src="https://unpkg.com/remarkable@1.7.1/dist/remarkable.min.js"></script>
+<script src="https://cdn.rawgit.com/showdownjs/showdown/1.4.3/dist/showdown.min.js"></script>
 <script type="text/jsx">
 
 var Lineup = React.createClass({
@@ -146,6 +146,7 @@ var Lineup = React.createClass({
   },
   appendToLineup: function(event) {
     var detail = event.detail
+    console.log("Detail: " + details)
     var newLineup = this.state.lineup.slice(0);
     newLineup.push(this.createInstance(detail.context, detail.site, detail.slug, detail.title))
     this.setState({ lineup: newLineup })
@@ -494,43 +495,55 @@ var ResolvedText = React.createClass({
     }
 })
 
-var MarkedText = React.createClass({
-  rawMarkup: function() {
-    var md = new Remarkable('full')
-    var rawMarkup = md.render(this.props.text.toString())
-    rawMarkup = rawMarkup.replace(/\<h[12]/gi, '<h3')
-    rawMarkup = rawMarkup.replace(/\<li\>\[x\]/gi, '<li>&#9745; ')
-    rawMarkup = rawMarkup.replace(/\<li\>\[ \]/gi, '<li>&#9744; ')
-    return { __html: rawMarkup }
-  },
-  
-  render: function(){
-        return <span dangerouslySetInnerHTML={this.rawMarkup()} />
-    }
-})
 
 var MarkdownText = React.createClass({
-    render: function(){
-        function splitText(text) {
-          return text.split(/(\[https?:.*? .*?\]|\[\[.*?\]\])/)
+    rawMarkup: function() {
+        var context = this.props.context
+        var wikiLinks = function () {
+            return [
+                {
+                    type:   'lang',
+                    regex:  /\[(https?:.*?) (.*?)\]/g,
+                    replace: function (match, url, linkText) {
+                        return '<a href="' + url + '" target="_blank">' + linkText + ' <img src="external-link-ltr-icon.png" /></a>'
+                    }
+                },
+                {
+                    type:   'lang',
+                    regex:  /\[\[(.*?)\]\]/g,
+                    replace: function (match, linkText) {
+                        var asSlug = function(title) {
+                            return title.replace(/\s/g, '-').replace(/[^A-Za-z0-9-]/g, '').toLowerCase()
+                        }
+                        var contextTitle = context.join(" ⇒ ")
+                        return '<a href="#" class="internal" title="' + contextTitle + '" data-page-name="' + asSlug(linkText) + '">' + linkText + '</a>'
+                    }
+                }
+            ]
         }
-
-        function span(props) {
-          return function (split, index) {
-            if (split.startsWith("[[")) {
-              return <InternalLink key={index} {...props} text={split.slice(2, -2)} />
-            }
-            else if (split.startsWith("[")) {
-              return <ExternalLink key={index} {...props} text={split} />
-            }
-            else {
-              return <MarkedText key={index} {...props} text={split} />
-            }
-          }
+        
+        var converter = new showdown.Converter({
+            headerLevelStart: 3,
+            tasklists: true,
+            extensions: [ wikiLinks ]
+        })
+        rawMarkup = converter.makeHtml(this.props.text)
+        return { __html: rawMarkup}
+    },
+    
+    onClick: function(e) {
+        var $target = $(e.target)
+        if ($target.is('a.internal')) {
+            var detail = { context: this.props.context, instance: this.props.instance, title: $target.title, slug: $target.data('pageName') }
+            var eventType = e.nativeEvent.shiftKey ? 'appendToLineup' : 'replaceInLineup'
+            var event = new CustomEvent(eventType, { detail: detail })
+            window.dispatchEvent(event)
+            e.preventDefault()
         }
-
-        var spans = splitText(this.props.text)
-        return <span>{spans.map(span(this.props))}</span>
+    },
+    
+    render: function() {
+        return <span onClick={this.onClick} dangerouslySetInnerHTML={this.rawMarkup()} />
     }
 })
 

--- a/index.html
+++ b/index.html
@@ -532,9 +532,9 @@ var MarkdownText = React.createClass({
     },
     
     onClick: function(e) {
-        var $target = $(e.target)
-        if ($target.is('a.internal')) {
-            var detail = { context: this.props.context, instance: this.props.instance, title: $target.title, slug: $target.data('pageName') }
+        var target = e.target
+        if (target.querySelectorAll('a.internal')) {
+            var detail = { context: this.props.context, instance: this.props.instance, title: target.getAttribute('title'), slug: target.getAttribute('data-page-name') }
             var eventType = e.nativeEvent.shiftKey ? 'appendToLineup' : 'replaceInLineup'
             var event = new CustomEvent(eventType, { detail: detail })
             window.dispatchEvent(event)


### PR DESCRIPTION
This switches to using [showdown](https://github.com/showdownjs/showdown) to render the markdown items.

An `extension` is added to convert wiki links, `showdown` options are used to enable GFM tasklists, and to start headers at level 3 (<h3>).

This converts the markdown as a html string, so we have to use `dangerouslySetInnerHTML` still, and add an `onClick` to `MarkdownText`.
